### PR TITLE
Added fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ vpo
 [![Build Status](https://travis-ci.org/unlucio/vpo.svg?branch=master)](https://travis-ci.org/unlucio/vpo)
 
 #### Value/path helper functions for javascript objects
+
 It's a set of simple functions that let you query or set values on your objects by a given string path.
 
 ##### How to get it:
@@ -62,10 +63,8 @@ vpo.setValueByPath('resetBao', 'key1.foo2.bar2', testObj);
 
 getting a value:
 ```javascript
-vpo.geValueByPath(testObj, 'key1.foo2.bar2');
+vpo.getValueByPath(testObj, 'key1.foo2.bar2');
 ```
-
-
 
 ===
 ###### I'm not sure who will ever be so "brave" to use it, but I'll leave it in since a dear friend of mine LOVES it :D

--- a/test/testVpo.js
+++ b/test/testVpo.js
@@ -63,10 +63,20 @@ describe('Vpo tests', function () {
 			assert.equal("bao", value, "Cannot read value!");
 		});
 		
+		it('Returns a fallback value if provided and it cannot find the object path', function () {
+			var value = vpo.getValueByPath(testObj, 'AGH', 11);
+			assert.equal(11, value, "Cannot read value!");
+		});
+		
+		it('Returns a fallback value if provided and it cannot find a deep object path', function () {
+			var value = vpo.getValueByPath(testObj, 'AGH.some.Error', 11);
+			assert.equal(11, value, "Cannot read value!");
+		});
+		
 		it('Can find a path by matching a value', function () {
 			var value = vpo.getPathByMatchingValue(testObj, 'bao12');
 			assert.equal("key3.foo2.bar2", value, "Cannot find path by  matching value!");
-		});
+		});		
 	});
 
 	describe('Attaching to Object.prototype', function () {
@@ -80,6 +90,12 @@ describe('Vpo tests', function () {
 			vpo.setOnObjectPrototype();
 			var value = testObj.getValueByPath('key1.foo2.bar2');
 			assert.equal("bao", value, "Cannot read value!");
+		});
+		
+		it('Supports fallbacks while looking up a value', function () {
+			vpo.setOnObjectPrototype();
+			var value = testObj.getValueByPath('oops.some.non.existing.property', 11);
+			assert.equal(11, value, "Cannot read value!");
 		});
 	});
 

--- a/vpo.js
+++ b/vpo.js
@@ -11,18 +11,19 @@
     }
   }
 
-  function getValueByPath(object, path) {
+  function getValueByPath(object, path, fallback) {
     var nextPath = '';
     var splitPath = path.split('.');
-
     if (object.hasOwnProperty(splitPath[0])) {
       if (splitPath.length > 1) {
         nextPath = path.replace(splitPath[0] + '.', '');
-        return getValueByPath(object[splitPath[0]], nextPath);
+        return getValueByPath(object[splitPath[0]], nextPath, fallback);
       } else {
         return object[splitPath[0]];
       }
     }
+    
+    return fallback;
   }
 
   function getPathByMatchingValue(obj, value) {
@@ -62,8 +63,8 @@
       setValueByPath(value, path, this);
     };
 
-    Object.prototype.getValueByPath = function(path) {
-      return getValueByPath(this, path);
+    Object.prototype.getValueByPath = function(path, fallback) {
+      return getValueByPath(this, path, fallback);
     };
   };
 })(typeof exports === 'undefined' ? this['vpo'] = {} : exports);


### PR DESCRIPTION
I am using vpo in some userland code and I wanted an easy way to support fallback values without writing `||` every time.

``` javascript
vpo.getValueByPath(window, 'some.property', 'fallbackValue')
```
