### PR TITLE
Changed the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
-vpo
-===
+# VPO
 
 [![Build Status](https://travis-ci.org/unlucio/vpo.svg?branch=master)](https://travis-ci.org/unlucio/vpo)
 
 #### Value/path helper functions for javascript objects
+
 It's a set of simple functions that let you query or set values on your objects by a given string path.
 
-##### How to get it:
-either:
+## How to get it:
+
+Either:
+
 ```
 git clone git://github.com/unlucio/vpo.git
 ```
+
 or
+
 ```
 npm install vpo
 ```
+
 or
+
 ```
 bower install vpo
 ```
 
+## Examples:
 
-##### examples:
-
-given the following dummy object:
+Given the following dummy object:
 
 ```javascript
 {
@@ -54,22 +59,22 @@ given the following dummy object:
 }
 ```
 
-
 setting a value:
-```javascript
-vpo.setValueByPath('resetBao', 'key1.foo2.bar2', testObj);
+
+``` javascript
+vpo.set('key1.foo2.bar2', testObj, 'resetBao');
 ```
 
 getting a value:
-```javascript
-vpo.geValueByPath(testObj, 'key1.foo2.bar2');
+
+``` javascript
+vpo.get(testObj, 'key1.foo2.bar2');
 ```
 
+## I'm not sure who will ever be so "brave" to use it, but I'll leave it in since a dear friend of mine LOVES it :D
 
-
-===
-###### I'm not sure who will ever be so "brave" to use it, but I'll leave it in since a dear friend of mine LOVES it :D
 ~~For convenince you can attach VPO to Object's prototype and have all your objects with 2 new methods:~~
-```javascript
+
+``` javascript
 vpo.setOnObjectPrototype();
 ```

--- a/test/testVpo.js
+++ b/test/testVpo.js
@@ -45,26 +45,26 @@ describe('Vpo tests', function () {
 	});
 
 	it('Doesn\'t crash setting random key', function () {
-		vpo.setValueByPath('resetBao', 'key1.blah.bar2', testObj);
+		vpo.set(testObj, 'key1.blah.bar2', 'resetBao');
 	});
 
 	it('Doesn\'t crash getting random key', function () {
-		vpo.getValueByPath(testObj, 'key1.blah.bar2');
+		vpo.get(testObj, 'key1.blah.bar2');
 	});
 
 	describe('Alone functions', function () {
 		it('Can set a value', function () {
-			vpo.setValueByPath('resetBao', 'key1.foo2.bar2', testObj);
+			vpo.set(testObj, 'key1.foo2.bar2', 'resetBao');
 			assert.equal("resetBao", testObj.key1.foo2.bar2, "Cannot set value!");
 		});
 
 		it('Can get a value', function () {
-			var value = vpo.getValueByPath(testObj, 'key1.foo2.bar2');
+			var value = vpo.get(testObj, 'key1.foo2.bar2');
 			assert.equal("bao", value, "Cannot read value!");
 		});
 		
 		it('Can find a path by matching a value', function () {
-			var value = vpo.getPathByMatchingValue(testObj, 'bao12');
+			var value = vpo.getByValue(testObj, 'bao12');
 			assert.equal("key3.foo2.bar2", value, "Cannot find path by  matching value!");
 		});
 	});
@@ -72,13 +72,13 @@ describe('Vpo tests', function () {
 	describe('Attaching to Object.prototype', function () {
 		it('Can set a value', function () {
 			vpo.setOnObjectPrototype();
-			testObj.setValueByPath('resetBao', 'key1.foo2.bar2');
+			testObj.set('key1.foo2.bar2', 'resetBao');
 			assert.equal("resetBao", testObj.key1.foo2.bar2, "Cannot set value!");
 		});
 
 		it('Can get a value', function () {
 			vpo.setOnObjectPrototype();
-			var value = testObj.getValueByPath('key1.foo2.bar2');
+			var value = testObj.get('key1.foo2.bar2');
 			assert.equal("bao", value, "Cannot read value!");
 		});
 	});

--- a/vpo.js
+++ b/vpo.js
@@ -1,11 +1,11 @@
 (function(vpo) {
-  function setValueByPath(value, path, object) {
+  function setValueByPath(object, path, value) {
     var splitPath = path.split('.');
     var key = splitPath.shift();
 
     if (splitPath.length >0) {
       object[key] = object[key] || {};
-      setValueByPath(value, splitPath.join('.'), object[key]);
+      setValueByPath(object[key], splitPath.join('.'), value);
     } else {
       object[key] = value;
     }
@@ -53,16 +53,16 @@
     return finalPath;
   }
 
-  vpo.setValueByPath = setValueByPath;
-  vpo.getValueByPath = getValueByPath;
-  vpo.getPathByMatchingValue = getPathByMatchingValue;
+  vpo.set = setValueByPath;
+  vpo.get = getValueByPath;
+  vpo.getByValue = getPathByMatchingValue;
 
   vpo.setOnObjectPrototype = function() {
-    Object.prototype.setValueByPath = function(value, path) {
-      setValueByPath(value, path, this);
+    Object.prototype.set = function(path, value) {
+      setValueByPath(this, path, value);
     };
 
-    Object.prototype.getValueByPath = function(path) {
+    Object.prototype.get = function(path) {
       return getValueByPath(this, path);
     };
   };


### PR DESCRIPTION
I was randomly using VPO and realized function names are a bit verbose, ie. `getValueByPath` can be just `get`.

At the same time I saw that set / get functions had inconsistent signatures:
- get: `obj, path`
- set: `value, path, object`

If we wanna keep the value as first argument of the setter, then I think we should still use the same order, for the order parameters, that is used in the getter, so `set(value, object, path)`.

I anyhow changed  it to `set(obj, path, value)` as - to me - it reads more natural. Let me know what you think.

Cheers!
